### PR TITLE
Change from radix/v4 to go-redis due to high lock overhead on EncodeDecode. Current best performance vs all previous versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,7 @@ Thumbs.db
 # Coverage Results #
 ####################
 coverage.txt
+
+# Profiler Results #
+####################
+*.pprof

--- a/subscriber.go
+++ b/subscriber.go
@@ -68,7 +68,6 @@ func subscriberRoutine(addr string, mode, subscriberName string, channel string,
 		_, _, ps, _ := bootstrapPubSub(addr, subscriberName, channel, opts)
 		defer ps.Close()
 		for {
-			ps.
 			msg, err := ps.Next(ctx)
 			if errors.Is(err, context.Canceled) {
 				break
@@ -100,7 +99,7 @@ func bootstrapPubSub(addr string, subscriberName string, channel string, opts ra
 	}
 
 	// Pass that connection into PubSub, conn should never get used after this
-	ps := radix.PubSubConfig{}.New(conn)
+	ps := radix.PubSubConfig{PingInterval: -1}.New(conn)
 
 	err = ps.Subscribe(ctx, channel)
 	if err != nil {


### PR DESCRIPTION
EncodeDecode now acquires a lock on radix/v4 which can represent a large overhead in scenarios of high load. 

![image](https://github.com/redis-performance/pubsub-sub-bench/assets/5832149/4c554c4a-cc8c-4f74-8bea-844edd48dcca)

To avoid having radix/v4 impact this benchmark tool we're moving to the go-redis client ( with the change of https://github.com/redis/go-redis/pull/2570 )

### Results of v0.0.6 ( radix/v3 ) -- -- Message Rate 796851
```
$ ./pubsub-sub-bench-v6 --subscribers-per-channel 9 --channel-minimum 1 --channel-maximum 100 --subscriber-prefix "channel-" --test-time 30 -oss-cluster-api-distribute-subscribers -port 30001
Using a redis connection, read, and write timeout of 5m0s
Total subcriptions: 900. Subscriptions per node 33. Total messages: 0
                Test Time           Total Messages            Message Rate 
                        1                        0                     0.00
                        2                        0                     0.00
                        3                        0                     0.00
                        0                  1205332               1205804.09
                        1                  3279948               2074637.68
                        2                  5381694               2101749.42
                        3                  7222575               1840869.60
                        4                  7903669                680847.21
                        5                  8510635                607133.51
                        6                  9080899                570289.51
                        7                  9576004                494961.59
                        8                 10098022                522140.39
                        9                 10669188                571112.24
                       10                 11214725                545184.65
                       11                 11794417                580110.31
                       12                 12415444                621038.16
                       13                 13030761                615289.53
                       14                 13623791                592875.27
                       15                 14251707                628111.81
                       16                 14872098                620169.72
                       17                 15502107                630174.03
                       18                 16147556                645452.92
                       19                 16817223                669706.92
                       20                 17445035                627653.26
                       21                 18068609                622935.82
                       22                 18701700                633902.44
                       23                 19371614                669444.46
                       24                 20035524                664376.64
                       25                 20713281                677755.52
                       26                 21353584                640305.12
                       27                 21985046                631436.20
                       28                 22600629                615602.13
                       29                 23267512                666889.69
                       30                 23905595                638040.48
#################################################
Total Duration 30.000183 Seconds
Message Rate 796851.240403
#################################################
```

### Results of v0.0.7 forward ( radix/v4 ) -- Message Rate 295370
```
$ ./pubsub-sub-bench-v10 --subscribers-per-channel 9 --channel-minimum 1 --channel-maximum 100 --subscriber-prefix "channel-" --test-time 30 -oss-cluster-api-distribute-subscribers -port 30001
Total subcriptions: 900. Subscriptions per node 33. Total messages: 0
                Test Time           Total Messages            Message Rate 
                        1                        0                     0.00
                        2                        0                     0.00
                        3                        0                     0.00
                        0                   330896                330925.78
                        1                  1240395                909512.67
                        2                  2165960                925556.85
                        3                  2607086                441119.83
                        4                  2820653                213505.69
                        5                  3021240                200646.93
                        6                  3235036                213759.13
                        7                  3459384                224372.36
                        8                  3676032                216658.85
                        9                  3900371                224228.38
                       10                  4132584                232330.28
                       11                  4361696                229112.13
                       12                  4598904                236872.22
                       13                  4841790                243231.08
                       14                  5087062                245271.77
                       15                  5343340                256274.38
                       16                  5607536                264151.35
                       17                  5865669                258168.59
                       18                  6125735                260066.88
                       19                  6379983                254053.63
                       20                  6614535                234750.09
                       21                  6856175                241573.04
                       22                  7121330                265227.60
                       23                  7378425                256743.70
                       24                  7609830                229493.78
                       25                  7801219                193255.65
                       26                  8040349                239136.00
                       27                  8286861                246515.43
                       28                  8537397                250411.21
                       29                  8738719                201421.83
                       30                  8871914                129827.87
#################################################
Total Duration 30.038005 Seconds
Message Rate 295370.982721
#################################################
```

### Results of this branch ( go-redis ) -- Message Rate 865977

```
$ ./pubsub-sub-bench --subscribers-per-channel 9 --channel-minimum 1 --channel-maximum 100 --subscriber-prefix "channel-" --test-time 30 -resp 3 -oss-cluster-api-distribute-subscribers -port 30001
Total subcriptions: 900. Subscriptions per node 33. Total messages: 0
                Test Time           Total Messages            Message Rate 
                        1                        0                     0.00
                        2                        0                     0.00
                        3                        0                     0.00
                        4                        0                     0.00
                        5                        0                     0.00
                        6                        0                     0.00
                        0                   714532                702371.38
                        1                  2815921               2101394.41
                        2                  4844112               2028179.14
                        3                  6978932               2134828.82
                        4                  9134354               2155381.41
                        5                 11271022               2136539.29
                        6                 13370608               2099546.12
                        7                 14287113                916590.87
                        8                 15012084                724831.53
                        9                 15708691                696724.43
                       10                 16444112                735427.34
                       11                 17155053                710378.81
                       12                 17881991                727485.77
                       13                 18602562                720598.80
                       14                 19346779                744074.36
                       15                 20092204                745575.03
                       16                 20807102                714836.51
                       17                 21586259                778518.27
                       18                 22375865                789725.48
                       19                 23167059                791474.26
                       20                 23926495                759597.44
                       21                 24576444                648873.99
                       22                 25155747                580145.35
                       23                 25446430                290672.93
                       24                 25783630                336173.76
                       25                 26010858                227649.34
                       26                 26087085                 73437.40
                       29                 26122086                 12544.18
                       30                 26123022                   728.27
#################################################
Total Duration 30.165971 Seconds
Message Rate 865977.670712
#################################################
```