### PR TITLE
In case of different slot groups count and node count ensure we iterate over nodes and node slots

### DIFF
--- a/subscriber.go
+++ b/subscriber.go
@@ -202,6 +202,13 @@ func main() {
 		}
 		nodeCount, nodeClients, nodesAddresses = updateSecondarySlicesCluster(clusterClient, ctx)
 	}
+
+	log.Println(fmt.Sprintf("Detailing final setup used for benchmark."))
+	log.Println(fmt.Sprintf("\tTotal nodes: %d", nodeCount))
+	for i, nodeAddress := range nodesAddresses {
+		log.Println(fmt.Sprintf("\tnode #%d: Address: %s", i, nodeAddress))
+		log.Println(fmt.Sprintf("\t\tClient struct: %v", nodeClients[i]))
+	}
 	// trap Ctrl+C and call cancel on the context
 	// We Use this instead of the previous stopChannel + chan radix.PubSubMessage
 	ctx, cancel := context.WithCancel(ctx)
@@ -348,7 +355,7 @@ func updateSecondarySlicesCluster(clusterClient *redis.ClusterClient, ctx contex
 		return
 	}
 	clusterClient.ForEachMaster(ctx, fn)
-	nodeCount = len(slots)
+	nodeCount = len(nodesAddresses)
 	return nodeCount, nodeClients, nodesAddresses
 }
 


### PR DESCRIPTION
Fixes the bellow log detail. Notice we have 4 nodes and 18 slot groups:
```
2023/06/15 14:14:38 Getting cluster slots info.
2023/06/15 14:14:38 Detailing cluster slots info. Total slot groups: 18
2023/06/15 14:14:38 	Slot range start 1820 end 2730. Nodes: [{5 10.0.101.38:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 5461 end 6371. Nodes: [{5 10.0.101.38:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 9102 end 10011. Nodes: [{5 10.0.101.38:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 12743 end 13652. Nodes: [{5 10.0.101.38:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 0 end 909. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 3641 end 4550. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 7282 end 8191. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 10923 end 11832. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 14564 end 15473. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 910 end 1819. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 4551 end 5460. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 8192 end 9101. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 11833 end 12742. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 15474 end 16383. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 2731 end 3640. Nodes: [{6 10.0.101.71:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 6372 end 7281. Nodes: [{6 10.0.101.71:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 10012 end 10922. Nodes: [{6 10.0.101.71:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 13653 end 14563. Nodes: [{6 10.0.101.71:10522 map[]}]
2023/06/15 14:14:38 Detailing cluster node info
2023/06/15 14:14:38 Cluster node pos #1. Address: 10.0.101.89:10522.
2023/06/15 14:14:38 Cluster node pos #2. Address: 10.0.101.71:10522.
2023/06/15 14:14:38 Cluster node pos #3. Address: 10.0.101.152:10522.
2023/06/15 14:14:38 Cluster node pos #4. Address: 10.0.101.38:10522.
2023/06/15 14:14:38 Total subcriptions: 900. Subscriptions per node 50. Total messages: 0
2023/06/15 14:14:38 Will use a subscriber prefix of: channel-<channel id>
2023/06/15 14:14:38 Setting per Node pool size of 50 given you haven't specified a value and we have 50 Subscriptions per node. You can control this option via --pool_size=<value>
2023/06/15 14:14:38 Reloading cluster state given we've changed pool size.
2023/06/15 14:14:38 Getting cluster slots info.
2023/06/15 14:14:38 Detailing cluster slots info. Total slot groups: 18
2023/06/15 14:14:38 	Slot range start 1820 end 2730. Nodes: [{5 10.0.101.38:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 5461 end 6371. Nodes: [{5 10.0.101.38:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 9102 end 10011. Nodes: [{5 10.0.101.38:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 12743 end 13652. Nodes: [{5 10.0.101.38:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 0 end 909. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 3641 end 4550. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 7282 end 8191. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 10923 end 11832. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 14564 end 15473. Nodes: [{3 10.0.101.89:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 910 end 1819. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 4551 end 5460. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 8192 end 9101. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 11833 end 12742. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 15474 end 16383. Nodes: [{4 10.0.101.152:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 2731 end 3640. Nodes: [{6 10.0.101.71:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 6372 end 7281. Nodes: [{6 10.0.101.71:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 10012 end 10922. Nodes: [{6 10.0.101.71:10522 map[]}]
2023/06/15 14:14:38 	Slot range start 13653 end 14563. Nodes: [{6 10.0.101.71:10522 map[]}]
2023/06/15 14:14:38 Detailing cluster node info
2023/06/15 14:14:38 Cluster node pos #1. Address: 10.0.101.38:10522.
2023/06/15 14:14:38 Cluster node pos #2. Address: 10.0.101.89:10522.
2023/06/15 14:14:38 Cluster node pos #3. Address: 10.0.101.152:10522.
2023/06/15 14:14:38 Cluster node pos #4. Address: 10.0.101.71:10522.
panic: runtime error: index out of range [4] with length 4
```