### PR TITLE
Reconnection Improvements, Channel Metrics, and Random Seed Support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,8 @@ jobs:
         goos: [linux, darwin]
         goarch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v3
-      - uses: wangyoucao577/go-release-action@v1.36
+      - uses: actions/checkout@v4
+      - uses: wangyoucao577/go-release-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}


### PR DESCRIPTION




### 1. Subscription and Reconnection Metrics
- **New Metric**: `totalSubscribedChannels` tracks the number of currently subscribed channels across all subscribers, providing real-time insights into subscription activity.
- **Reconnection Metric**: `totalConnects` tracks the total number of reconnection events for enhanced visibility into reconnection patterns.

### 2. Improved Reconnection Logic
- **Multi-Channel Handling**: 
  - Only unsubscribes/resubscribes additional channels (excluding the first channel) to minimize unnecessary overhead.
- **Single-Channel Optimization**: Logs when reconnection operations are skipped for subscribers with only one channel.
- Precise reconnection intervals now support millisecond granularity for fine-tuned performance scenarios.

### 3. Randomized Behavior with Deterministic Seed
- Added a `--rand-seed` flag to set a deterministic random seed, ensuring reproducible test scenarios.
- Randomized:
  - Channels per subscriber connection (`--min-number-channels-per-subscriber`, `--max-number-channels-per-subscriber`).
  - Reconnection intervals (`--min-reconnect-interval`, `--max-reconnect-interval`).

### 4. Enhanced CLI Output
- Added **"Connect Rate"**: Displays reconnection events per second in real-time.
- Added **"Active Subscriptions"**: Displays the total number of active channel subscriptions at any given time.
- Improved layout for clarity and readability.

### 5. Additional Logging
- Logs the total number of channels per subscriber and their names at startup.
- Logs when reconnection intervals are skipped or applied.
