### PR TITLE
Add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent guidelines
+
+Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working in this repo.
+
+## Project overview
+
+<!-- TODO: one paragraph describing what this repo does -->
+
+## Local setup
+
+<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
+
+```bash
+# Example
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+```
+
+## Branch naming
+
+Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-in-pipeline`).
+
+## Coding standards
+
+- Match the style already in the file you are editing.
+- Prefer clear, minimal changes over large refactors unless explicitly asked.
+- Do not add comments that describe *what* the code does — only add comments when the *why* is non-obvious.
+- Do not introduce new dependencies without checking with the maintainer.
+
+## Running tests
+
+<!-- TODO: exact command to run tests -->
+
+```bash
+# Example
+make test
+```
+
+Always run tests before declaring a task complete.
+
+## How to submit changes
+
+1. Create a branch: `git checkout -b <type>/<description>`.
+2. Commit with a clear message focused on *why*, not *what*.
+3. Open a pull request against `main`.
+4. Do **not** push directly to `main`.
+
+## What to avoid
+
+- Do not reformat files unrelated to your change.
+- Do not remove error handling or tests.
+- Do not commit secrets, credentials, or large binary files.
+- Do not amend published commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,24 @@ Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working i
 
 ## Project overview
 
-<!-- TODO: one paragraph describing what this repo does -->
+`pubsub-sub-bench` is a Go benchmarking tool that mimics the subscriber workload in a Redis Pub/Sub system. It connects multiple subscriber clients to Redis, subscribes them to configurable channel ranges, and measures throughput and (optionally) round-trip latency. It supports standard Pub/Sub (`SUBSCRIBE`/`PUBLISH`), sharded Pub/Sub (`SSUBSCRIBE`/`SPUBLISH`), Redis OSS Cluster topology, and a built-in publisher mode with rate limiting — making it a self-contained load generator for validating Redis Pub/Sub performance.
 
 ## Local setup
 
-<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
+This is a Go project. You need Go 1.23 or later (Go 1.24 recommended).
 
 ```bash
-# Example
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
+git clone git@github.com:redis-performance/pubsub-sub-bench.git
+cd pubsub-sub-bench
+
+# Download all dependencies
+go mod download
+
+# Build the binary
+make build
 ```
+
+The resulting binary is `./pubsub-sub-bench` in the repo root.
 
 ## Branch naming
 
@@ -29,11 +36,16 @@ Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-i
 
 ## Running tests
 
-<!-- TODO: exact command to run tests -->
+Run the full test suite (downloads dependencies, checks formatting, runs tests with the race detector):
 
 ```bash
-# Example
 make test
+```
+
+To also generate a coverage report:
+
+```bash
+make coverage
 ```
 
 Always run tests before declaring a task complete.
@@ -42,8 +54,8 @@ Always run tests before declaring a task complete.
 
 1. Create a branch: `git checkout -b <type>/<description>`.
 2. Commit with a clear message focused on *why*, not *what*.
-3. Open a pull request against `main`.
-4. Do **not** push directly to `main`.
+3. Open a pull request against `master`.
+4. Do **not** push directly to `master`.
 
 ## What to avoid
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+We treat this repo as "Open Source" within Redis: anyone who clears the bar below is welcome to contribute.
+
+## Local setup
+
+<!-- TODO: fill in repo-specific setup steps -->
+
+```bash
+# Example — replace with actual steps
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+# install dependencies, build, etc.
+```
+
+## Branch naming
+
+```
+<type>/<short-description>
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+Example: `feat/add-pipeline-mode`
+
+## Coding standards
+
+- Keep changes focused; one logical change per PR.
+- Follow the conventions already present in the codebase (formatting, naming, error handling).
+- No dead code, no commented-out blocks.
+
+## Submitting changes
+
+1. Fork or create a branch from `main`.
+2. Make your changes with clear, atomic commits.
+3. Open a pull request against `main` with a descriptive title and summary.
+4. Address review comments promptly; force-push to the same branch to update.
+
+## Testing
+
+- All new behaviour must be covered by tests.
+- Existing tests must pass: run the test suite locally before opening a PR.
+- Coverage should not decrease.
+
+<!-- TODO: add the exact test command for this repo -->
+
+## Review process
+
+- At least one maintainer approval is required before merge.
+- CI must be green.
+- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,23 @@ We treat this repo as "Open Source" within Redis: anyone who clears the bar belo
 
 ## Local setup
 
-<!-- TODO: fill in repo-specific setup steps -->
+This is a Go project. You need Go 1.23 or later (Go 1.24 recommended).
 
 ```bash
-# Example — replace with actual steps
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
-# install dependencies, build, etc.
+git clone git@github.com:redis-performance/pubsub-sub-bench.git
+cd pubsub-sub-bench
+
+# Download all dependencies
+go mod download
 ```
+
+To build the binary:
+
+```bash
+make build
+```
+
+This produces a `pubsub-sub-bench` binary in the current directory.
 
 ## Branch naming
 
@@ -31,9 +40,9 @@ Example: `feat/add-pipeline-mode`
 
 ## Submitting changes
 
-1. Fork or create a branch from `main`.
+1. Fork or create a branch from `master`.
 2. Make your changes with clear, atomic commits.
-3. Open a pull request against `main` with a descriptive title and summary.
+3. Open a pull request against `master` with a descriptive title and summary.
 4. Address review comments promptly; force-push to the same branch to update.
 
 ## Testing
@@ -42,10 +51,26 @@ Example: `feat/add-pipeline-mode`
 - Existing tests must pass: run the test suite locally before opening a PR.
 - Coverage should not decrease.
 
-<!-- TODO: add the exact test command for this repo -->
+Run the full test suite (downloads dependencies, checks formatting, runs tests with race detector):
+
+```bash
+make test
+```
+
+To also generate a coverage report:
+
+```bash
+make coverage
+```
+
+To check formatting only:
+
+```bash
+make checkfmt
+```
 
 ## Review process
 
 - At least one maintainer approval is required before merge.
 - CI must be green.
-- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.
+- Maintainers may request changes or close PRs that do not meet the bar — this is normal and not personal.


### PR DESCRIPTION
## Summary
- Adds baseline `CONTRIBUTING.md` (project setup, coding standards, PR workflow, testing, review process)
- Adds `AGENTS.md` with AI agent guidelines

Part of the Redis "Open Source within Redis" initiative — ensuring every repo in the org has clear contribution and agent guidelines to enable cross-team contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)