### PR TITLE
fix: migrate docker-publish from Docker Hub to GHCR

### DIFF
--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -42,18 +42,6 @@ jobs:
         echo "git_dirty=${GIT_DIRTY}" >> $GITHUB_OUTPUT
         echo "short_sha=${GIT_SHA:0:7}" >> $GITHUB_OUTPUT
 
-    - name: Check Docker Hub credentials
-      id: check_credentials
-      run: |
-        if [[ -n "${{ secrets.DOCKER_USERNAME }}" && -n "${{ secrets.DOCKER_PASSWORD }}" ]]; then
-          echo "credentials_available=true" >> $GITHUB_OUTPUT
-          echo "✅ Docker Hub credentials are configured"
-        else
-          echo "credentials_available=false" >> $GITHUB_OUTPUT
-          echo "⚠️ Docker Hub credentials not configured (DOCKER_USERNAME and/or DOCKER_PASSWORD secrets missing)"
-          echo "This is expected for forks and external PRs. Docker build validation will still work."
-        fi
-
     - name: Build Docker image (single platform)
       uses: docker/build-push-action@v5
       with:
@@ -74,9 +62,9 @@ jobs:
 
         # Verify image was built
         if docker images | grep -q "${{ env.IMAGE_NAME }}"; then
-          echo "✅ Docker image built successfully"
+          echo "Docker image built successfully"
         else
-          echo "❌ Docker image not found"
+          echo "Docker image not found"
           exit 1
         fi
 
@@ -88,7 +76,7 @@ jobs:
         echo "Testing --version command..."
         docker run --rm ${{ env.IMAGE_NAME }}:pr-${{ github.event.number }} --version
 
-        echo "✅ Docker image tests passed!"
+        echo "Docker image tests passed!"
 
     - name: Build multi-platform image (validation only)
       uses: docker/build-push-action@v5
@@ -108,33 +96,22 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const credentialsStatus = '${{ steps.check_credentials.outputs.credentials_available }}' === 'true'
-            ? '✅ Docker Hub credentials configured'
-            : '⚠️ Docker Hub credentials not configured (expected for forks)';
+          const output = `## Docker Build Validation
 
-          const output = `## 🐳 Docker Build Validation
-
-          ✅ **Docker build successful!**
+          **Docker build successful!**
 
           **Platforms tested:**
-          - ✅ linux/amd64 (built and tested)
-          - ✅ linux/arm64 (build validated)
+          - linux/amd64 (built and tested)
+          - linux/arm64 (build validated)
 
           **Git SHA:** \`${{ steps.meta.outputs.git_sha }}\`
 
-          **Docker Hub Status:** ${credentialsStatus}
-
-          **Image details:**
-          - Single platform: \`${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}\`
-          - Multi-platform: \`${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}-multiplatform\`
-
           **Tests performed:**
-          - ✅ Docker Hub credentials check
-          - ✅ Help command execution
-          - ✅ Version output validation
-          - ✅ Multi-platform build validation
+          - Help command execution
+          - Version output validation
+          - Multi-platform build validation
 
-          The Docker image is ready for deployment! 🚀`;
+          The Docker image is ready for deployment!`;
 
           github.rest.issues.createComment({
             issue_number: context.issue.number,

--- a/.github/workflows/docker-publish-master.yml
+++ b/.github/workflows/docker-publish-master.yml
@@ -12,8 +12,8 @@ on:
       - '.github/workflows/release-drafter.yml'
 
 env:
-  REGISTRY: docker.io
-  IMAGE_NAME: redis/pubsub-sub-bench
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/redis-performance/pubsub-sub-bench
 
 jobs:
   docker-publish:
@@ -34,20 +34,12 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    - name: Check Docker Hub credentials
-      run: |
-        if [[ -z "${{ secrets.DOCKER_USERNAME }}" || -z "${{ secrets.DOCKER_PASSWORD }}" ]]; then
-          echo "Docker Hub credentials not configured!"
-          echo "Please set DOCKER_USERNAME and DOCKER_PASSWORD secrets in repository settings."
-          exit 1
-        fi
-
-    - name: Log in to Docker Hub
+    - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4
       with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract Git metadata
       id: meta
@@ -84,8 +76,8 @@ jobs:
 
     - name: Generate summary
       run: |
-        echo "## 🐳 Docker Image Published" >> $GITHUB_STEP_SUMMARY
+        echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
         echo "**Repository:** \`${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
         echo "**Tags:** ${{ steps.docker_meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
         echo "**Git SHA:** \`${{ steps.meta.outputs.git_sha }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "🔗 [View on Docker Hub](https://hub.docker.com/r/${{ env.IMAGE_NAME }})" >> $GITHUB_STEP_SUMMARY
+        echo "[View on GHCR](https://github.com/orgs/redis-performance/packages/container/package/pubsub-sub-bench)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-publish-release.yml
+++ b/.github/workflows/docker-publish-release.yml
@@ -5,8 +5,8 @@ on:
     types: [published]
 
 env:
-  REGISTRY: docker.io
-  IMAGE_NAME: redis/pubsub-sub-bench
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/redis-performance/pubsub-sub-bench
 
 jobs:
   docker-publish:
@@ -27,19 +27,12 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    - name: Check Docker Hub credentials
-      run: |
-        if [[ -z "${{ secrets.DOCKER_USERNAME }}" || -z "${{ secrets.DOCKER_PASSWORD }}" ]]; then
-          echo "Docker Hub credentials not configured!"
-          exit 1
-        fi
-
-    - name: Log in to Docker Hub
+    - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4
       with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract Git metadata
       id: meta
@@ -90,9 +83,9 @@ jobs:
 
     - name: Generate summary
       run: |
-        echo "## 🚀 Docker Release Published" >> $GITHUB_STEP_SUMMARY
+        echo "## Docker Release Published" >> $GITHUB_STEP_SUMMARY
         echo "**Repository:** \`${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
         echo "**Release:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
         echo "**Tags:** ${{ steps.docker_meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-        echo "🔗 [View on Docker Hub](https://hub.docker.com/r/${{ env.IMAGE_NAME }})" >> $GITHUB_STEP_SUMMARY
-        echo "🔒 [Security Scan Results](https://github.com/${{ github.repository }}/security/code-scanning)" >> $GITHUB_STEP_SUMMARY
+        echo "[View on GHCR](https://github.com/orgs/redis-performance/packages/container/package/pubsub-sub-bench)" >> $GITHUB_STEP_SUMMARY
+        echo "[Security Scan Results](https://github.com/${{ github.repository }}/security/code-scanning)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Replaces Docker Hub credentials (`DOCKER_USERNAME` / `DOCKER_PASSWORD`) with GHCR (`ghcr.io`) using the built-in `GITHUB_TOKEN` — no external secrets needed.
- Updates `docker-publish-master.yml`, `docker-publish-release.yml`, and `docker-build-pr.yml` to target `ghcr.io/redis-performance/pubsub-sub-bench`.
- Removes the pre-flight "Check Docker Hub credentials" step that was hard-failing on stale secrets.
- `packages: write` permission was already present in the publish workflows; retained throughout.

## Files changed

- `.github/workflows/docker-publish-master.yml`
- `.github/workflows/docker-publish-release.yml`
- `.github/workflows/docker-build-pr.yml`

## Test plan

- [ ] Merge and verify a test push to master triggers `Docker Publish - Master` and successfully pushes to `ghcr.io/redis-performance/pubsub-sub-bench`
- [ ] Confirm no Docker Hub secrets are referenced anywhere in the updated workflows