### PR TITLE
docs: add Docker Hub and CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Unit Tests](https://github.com/redis-performance/pubsub-sub-bench/workflows/Unit%20Tests/badge.svg)](https://github.com/redis-performance/pubsub-sub-bench/actions/workflows/unit-tests.yml)
 [![Docker Build](https://github.com/redis-performance/pubsub-sub-bench/workflows/Docker%20Build%20-%20PR%20Validation/badge.svg)](https://github.com/redis-performance/pubsub-sub-bench/actions/workflows/docker-build-pr.yml)
 [![Docker Hub](https://img.shields.io/docker/pulls/filipe958/pubsub-sub-bench.svg)](https://hub.docker.com/r/filipe958/pubsub-sub-bench)
+[![Docker Pulls](https://img.shields.io/docker/pulls/redis/pubsub-sub-bench)](https://hub.docker.com/r/redis/pubsub-sub-bench)
+[![CI](https://github.com/redis-performance/pubsub-sub-bench/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/redis-performance/pubsub-sub-bench/actions/workflows/unit-tests.yml)
 
 
 ## Overview
@@ -229,4 +231,3 @@ Subscriber using sharded pub/sub
 ```
 
 This will distribute subscribers across cluster nodes in a round-robin manner.
-

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 [![codecov](https://codecov.io/github/redis-performance/pubsub-sub-bench/branch/main/graph/badge.svg?token=B6ISQSDK3Y)](https://codecov.io/github/redis-performance/pubsub-sub-bench)
 [![Unit Tests](https://github.com/redis-performance/pubsub-sub-bench/workflows/Unit%20Tests/badge.svg)](https://github.com/redis-performance/pubsub-sub-bench/actions/workflows/unit-tests.yml)
 [![Docker Build](https://github.com/redis-performance/pubsub-sub-bench/workflows/Docker%20Build%20-%20PR%20Validation/badge.svg)](https://github.com/redis-performance/pubsub-sub-bench/actions/workflows/docker-build-pr.yml)
-[![Docker Hub](https://img.shields.io/docker/pulls/filipe958/pubsub-sub-bench.svg)](https://hub.docker.com/r/filipe958/pubsub-sub-bench)
-[![Docker Pulls](https://img.shields.io/docker/pulls/redis/pubsub-sub-bench)](https://hub.docker.com/r/redis/pubsub-sub-bench)
-[![CI](https://github.com/redis-performance/pubsub-sub-bench/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/redis-performance/pubsub-sub-bench/actions/workflows/unit-tests.yml)
+[![Docker Hub](https://img.shields.io/docker/pulls/redis/pubsub-sub-bench)](https://hub.docker.com/r/redis/pubsub-sub-bench)
 
 
 ## Overview
@@ -28,18 +26,14 @@ The easiest way to run pubsub-sub-bench is using Docker:
 
 ```bash
 # Pull the latest image
-docker pull filipe958/pubsub-sub-bench:latest
 
 # Run with help
-docker run --rm filipe958/pubsub-sub-bench:latest --help
 
 # Example: Subscribe to channels
-docker run --rm --network=host filipe958/pubsub-sub-bench:latest \
   -host localhost -port 6379 -mode subscribe \
   -clients 10 -test-time 30
 
 # Example: With JSON output (mount current directory)
-docker run --rm -v $(pwd):/app/output --network=host filipe958/pubsub-sub-bench:latest \
   -json-out-file results.json -host localhost -mode subscribe
 ```
 


### PR DESCRIPTION
Adds Docker Hub pull count badge and CI status badge to the README header.